### PR TITLE
Return variable name when using toString()

### DIFF
--- a/lib/src/param.dart
+++ b/lib/src/param.dart
@@ -19,7 +19,7 @@ class Variable {
 
   /// An optional name given to the variable. This is useful in debugging
   /// [Solver] state.
-  late String name;
+  String? name;
 
   /// Variables represent state inside the solver. This state is usually of
   /// interest to some entity outside the solver. Such entities can (optionally)
@@ -37,6 +37,9 @@ class Variable {
     value = updated;
     return res;
   }
+
+  @override
+  String toString() => name ?? super.toString();
 }
 
 /// A [Param] wraps a [Variable] and makes it suitable to be used in an
@@ -70,10 +73,13 @@ class Param extends EquationMember {
   double get value => variable.value;
 
   /// The name of the [Variable] associated with this [Param].
-  String get name => variable.name;
+  String? get name => variable.name;
 
   /// Set the name of the [Variable] associated with this [Param].
-  set name(String name) {
+  set name(String? name) {
     variable.name = name;
   }
+
+  @override
+  String toString() => name ?? super.toString();
 }

--- a/test/cassowary_test.dart
+++ b/test/cassowary_test.dart
@@ -386,16 +386,9 @@ void main() {
 
     final c = (left >= cm(0));
 
-    expect(
-        s.addConstraints(<Constraint>[
-          (left + right).equals(cm(2) * mid),
-          (right - left >= cm(100)),
-          c
-        ]),
-        Result.success);
+    expect(s.addConstraints(<Constraint>[(left + right).equals(cm(2) * mid), (right - left >= cm(100)), c]), Result.success);
 
-    expect(s.addConstraints(<Constraint>[(right >= cm(-20)), c]),
-        Result.duplicateConstraint);
+    expect(s.addConstraints(<Constraint>[(right >= cm(-20)), c]), Result.duplicateConstraint);
   });
 
   test('edit_constraints', () {
@@ -544,10 +537,7 @@ Instance of 'Variable' = Instance of '_Symbol'
     final right = Param(100);
     final mid = Param(0);
 
-    expect(
-        s.addEditVariables(
-            <Variable>[left.variable, right.variable, mid.variable], 999),
-        Result.success);
+    expect(s.addEditVariables(<Variable>[left.variable, right.variable, mid.variable], 999), Result.success);
   });
 
   test('bulk_remove_constraints_and_variables', () {
@@ -557,10 +547,7 @@ Instance of 'Variable' = Instance of '_Symbol'
     final right = Param(100);
     final mid = Param(0);
 
-    expect(
-        s.addEditVariables(
-            <Variable>[left.variable, right.variable, mid.variable], 999),
-        Result.success);
+    expect(s.addEditVariables(<Variable>[left.variable, right.variable, mid.variable], 999), Result.success);
 
     final c1 = left <= mid;
     final c2 = mid <= right;
@@ -569,10 +556,7 @@ Instance of 'Variable' = Instance of '_Symbol'
 
     expect(s.removeConstraints(<Constraint>[c1, c2]), Result.success);
 
-    expect(
-        s.removeEditVariables(
-            <Variable>[left.variable, right.variable, mid.variable]),
-        Result.success);
+    expect(s.removeEditVariables(<Variable>[left.variable, right.variable, mid.variable]), Result.success);
   });
 
   test('remove_unsatisfiable_constraint', () {
@@ -586,5 +570,14 @@ Instance of 'Variable' = Instance of '_Symbol'
     solver.addConstraint(c2);
     expect(solver.addConstraint(c3), Result.unsatisfiableConstraint);
     expect(solver.removeConstraint(c3), Result.success);
+  });
+
+  test('to_string_returns_variable_name', () {
+    final a = Param()..name = 'a';
+    final b = Param()..name = 'b';
+
+    expect(a.toString(), 'a');
+    expect(b.toString(), 'b');
+    expect(a.equals(b).toString(), startsWith('+a-b == 0'));
   });
 }


### PR DESCRIPTION
With this PR, `Variable` and `Param` `toString()` functions use the optional field `name`.
We end up with nice equations such as the following when printing constraints:
```
+a-b == 0  | priority = 1000000000.0 (required)
```

for 
```
final a = Param()..name = 'a';
final b = Param()..name = 'b';
print(a.equals(b));
```